### PR TITLE
Update paren patterns to retain parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ class HelloWorld
 
                          
   def hello
-          "World!"         
+         ("World!"        )
   end
 end
 ```

--- a/lib/sorbet/eraser/patterns.rb
+++ b/lib/sorbet/eraser/patterns.rb
@@ -33,8 +33,8 @@ module Sorbet
       # T.unsafe(foo) => foo
       class TOneArgMethodCallParensPattern < Pattern
         def replace(segment)
-          segment.gsub(/(T\s*\.(?:must|reveal_type|unsafe)\(\s*)(.+)(\s*\))(.*)/m) do
-            "#{blank($1)}#{$2}#{blank($3)}#{$4}"
+          segment.gsub(/(T\s*\.(?:must|reveal_type|unsafe))(\(\s*.+\s*\))(.*)/m) do
+            "#{blank($1)}#{$2}#{$3}"
           end
         end
       end
@@ -53,11 +53,14 @@ module Sorbet
           pre, post = 0...comma, comma..-1
 
           replacement[pre] =
-            replacement[pre].gsub(/(T\s*\.(?:assert_type!|bind|cast|let)\(\s*)(.+)/m) do
+            replacement[pre].gsub(/(T\s*\.(?:assert_type!|bind|cast|let))(\(\s*.+)/m) do
               "#{blank($1)}#{$2}"
             end
 
-          replacement[post] = blank(replacement[post])
+          replacement[post] =
+            replacement[post].gsub(/(.+)\)/m) do
+              "#{blank($1)})"
+            end
           replacement
         end
       end

--- a/test/sorbet/patterns_test.rb
+++ b/test/sorbet/patterns_test.rb
@@ -141,6 +141,28 @@ module Sorbet
         OUTPUT
       end
 
+      def test_method_requiring_parens
+        assert_erases(<<-INPUT, <<-OUTPUT)
+          foo = T.cast(1 + 2, Integer)
+        INPUT
+          foo =       (1 + 2         )
+        OUTPUT
+      end
+
+      def test_method_multiple_lines
+        assert_erases(<<-INPUT, <<-OUTPUT)
+          foo = T.cast(
+            1 + 2,
+            Integer
+          )
+        INPUT
+          foo =       (
+            1 + 2 
+                   
+          )
+        OUTPUT
+      end
+
       def test_t_struct
         assert_erases(<<-INPUT, <<-OUTPUT)
           class Foo < T::Struct

--- a/test/sorbet/patterns_test.rb
+++ b/test/sorbet/patterns_test.rb
@@ -51,7 +51,7 @@ module Sorbet
         assert_erases(<<-INPUT, <<-OUTPUT)
           foo = T.assert_type!(bar, String)
         INPUT
-          foo =                bar         
+          foo =               (bar        )
         OUTPUT
       end
 
@@ -59,7 +59,7 @@ module Sorbet
         assert_erases(<<-INPUT, <<-OUTPUT)
           foo = T.bind(self, String)
         INPUT
-          foo =        self         
+          foo =       (self        )
         OUTPUT
       end
 
@@ -67,7 +67,7 @@ module Sorbet
         assert_erases(<<-INPUT, <<-OUTPUT)
           foo = T.cast(bar, String)
         INPUT
-          foo =        bar         
+          foo =       (bar        )
         OUTPUT
       end
 
@@ -75,13 +75,13 @@ module Sorbet
         assert_erases(<<-INPUT, <<-OUTPUT)
           foo = T.let(bar, String)
         INPUT
-          foo =       bar         
+          foo =      (bar        )
         OUTPUT
 
         assert_erases(<<-INPUT, <<-OUTPUT)
           T.let("World!", String)
         INPUT
-                "World!"         
+               ("World!"        )
         OUTPUT
       end
 
@@ -89,7 +89,7 @@ module Sorbet
         assert_erases(<<-INPUT, <<-OUTPUT)
           KEYWORDS = T.let(%w[__FILE__ __LINE__ alias and begin BEGIN break case class def defined? do else elsif end END ensure false for if in module next nil not or redo rescue retry return self super then true undef unless until when while yield], T::Array[String])
         INPUT
-          KEYWORDS =       %w[__FILE__ __LINE__ alias and begin BEGIN break case class def defined? do else elsif end END ensure false for if in module next nil not or redo rescue retry return self super then true undef unless until when while yield]                   
+          KEYWORDS =      (%w[__FILE__ __LINE__ alias and begin BEGIN break case class def defined? do else elsif end END ensure false for if in module next nil not or redo rescue retry return self super then true undef unless until when while yield]                  )
         OUTPUT
       end
 
@@ -97,7 +97,7 @@ module Sorbet
         assert_erases(<<-INPUT, <<-OUTPUT)
           foo = T.must(bar)
         INPUT
-          foo =        bar 
+          foo =       (bar)
         OUTPUT
       end
 
@@ -113,7 +113,7 @@ module Sorbet
         assert_erases(<<-INPUT, <<-OUTPUT)
           T.reveal_type(foo)
         INPUT
-                        foo 
+                       (foo)
         OUTPUT
       end
 
@@ -129,7 +129,7 @@ module Sorbet
         assert_erases(<<-INPUT, <<-OUTPUT)
           T.unsafe(foo)
         INPUT
-                   foo 
+                  (foo)
         OUTPUT
       end
 


### PR DESCRIPTION
## Description 

This PR updates the patterns for replacements with parens so that they are retained during replacement. There could be cases where the parens are ensuring a proper parse of the file and removing them may mean it no longer parses correctly. 