### PR TITLE
Fix return value of `T::Private:Methods.signature_for_method`

### DIFF
--- a/lib/sorbet/eraser/t.rb
+++ b/lib/sorbet/eraser/t.rb
@@ -47,7 +47,7 @@ module T
       module SingletonMethodHooks
       end
 
-      def self.signature_for_method(method); method; end
+      def self.signature_for_method(method); nil; end
     end
   end
 


### PR DESCRIPTION
Since Sorbet runtime and all signatures are erased, this method should return `nil` to signal that there is no signature for the given method.

Returning `method` here is not correct, since the return value is expected to be a `Signature` instance that has a reference to the original method in the `method` property. An `UnboundMethod` instance does not satisfy this property.

Fixes: https://github.com/Shopify/tapioca/issues/1669