### PR TITLE
`T::Props#props` is expected to be a hash not an array

### DIFF
--- a/lib/sorbet/eraser/t/props.rb
+++ b/lib/sorbet/eraser/t/props.rb
@@ -16,7 +16,7 @@ module T
     # them and not raise errors and for bookkeeping.
     module ClassMethods
       def props
-        @props ||= []
+        @props ||= {}
       end
 
       def prop(name, rules = {})
@@ -32,8 +32,7 @@ module T
       private
 
       def create_prop(name, rules)
-        props << [name, rules]
-        props.sort_by!(&:first)
+        props[name] = rules
       end
     end
 


### PR DESCRIPTION
`T::Props#props` is public API of `T::Struct` and is used to enumerate all the properties defined on a typed struct.

The original implementation of this method, however, returns a hash with method name keys and rules as the value. Returning an array as the value of `props` violates this expectation.